### PR TITLE
z3 encoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,5 +16,5 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % "0.7.0",
   "io.circe" %% "circe-parser" % "0.7.0",
 
-  "org.kframework" %% "kore" % "0.5-SNAPSHOT"
+  "org.kframework.k" %% "kore" % "1.0-SNAPSHOT"
 )

--- a/src/main/scala/org/kframework/kale/Environment.scala
+++ b/src/main/scala/org/kframework/kale/Environment.scala
@@ -3,7 +3,7 @@ package org.kframework.kale
 import org.kframework.kale.standard.{Bottomize, Name, Sort}
 import org.kframework.kore
 
-import scala.collection.mutable
+import scala.collection._
 
 trait Environment extends KORELabels with Bottomize {
 
@@ -37,6 +37,10 @@ trait Environment extends KORELabels with Bottomize {
   def label(labelName: String): Label = uniqueLabels(labelName)
 
   def sort(l: Label, children: Seq[Term]): Sort
+
+  def sortArgs(l: Label): Seq[Sort]
+
+  def sortTarget(l: Label): Sort
 
   override def toString = {
     "nextId: " + uniqueLabels.size + "\n" + uniqueLabels.mkString("\n")

--- a/src/main/scala/org/kframework/kale/Rewriter.scala
+++ b/src/main/scala/org/kframework/kale/Rewriter.scala
@@ -43,6 +43,8 @@ class Rewriter(substitutioner: Substitution => (Term => Term), doMatch: Binary.A
 
   sortedRules ++= rules
 
+  val z3 = new z3(env)
+
   import env._
 
   def apply(t: Term): Stream[Term] = step(t)
@@ -80,7 +82,7 @@ class Rewriter(substitutioner: Substitution => (Term => Term), doMatch: Binary.A
         val res = Or.asSet(or).flatMap(u => {
           val (sub, terms) = And.asSubstitutionAndTerms(u)
           val constraints = And(terms)
-          if (sat(constraints)) {
+          if (z3.sat(constraints)) {
             Set(And(substitutioner(sub)(rhs), constraints)) // TODO: consider when rhs.predicates is not satisfiable with constraints
           } else {
             Set[Term]()
@@ -89,6 +91,4 @@ class Rewriter(substitutioner: Substitution => (Term => Term), doMatch: Binary.A
         res
     }))
   }
-
-  def sat(t: Term): Boolean = true // TODO(Daejun): implement
 }

--- a/src/main/scala/org/kframework/kale/Rewriter.scala
+++ b/src/main/scala/org/kframework/kale/Rewriter.scala
@@ -43,7 +43,7 @@ class Rewriter(substitutioner: Substitution => (Term => Term), doMatch: Binary.A
 
   sortedRules ++= rules
 
-  val z3 = new z3(env)
+  val z3 = new z3(env, Seq(Seq()))
 
   import env._
 

--- a/src/main/scala/org/kframework/kale/builtin/INT.scala
+++ b/src/main/scala/org/kframework/kale/builtin/INT.scala
@@ -25,6 +25,8 @@ trait HasINTdiv extends HasINT {
   }
 }
 
+trait HasINTcmp extends HasINTlt with HasINTle with HasINTgt with HasINTge { self: Environment => }
+
 trait HasINTlt extends HasINT with HasBOOLEAN { self: Environment =>
   val intLt = new Named("_<Int_")(self) with FunctionLabel2 with Z3Builtin {
     def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {

--- a/src/main/scala/org/kframework/kale/builtin/INT.scala
+++ b/src/main/scala/org/kframework/kale/builtin/INT.scala
@@ -31,7 +31,7 @@ trait HasINTlt extends HasINT with HasBOOLEAN { self: Environment =>
       case (INT(a), INT(b)) => Some(BOOLEAN(a < b))
       case _ => None
     }
-    override def smt: String = "<"
+    override def smtName: String = "<"
   }
 }
 
@@ -41,7 +41,7 @@ trait HasINTle extends HasINT with HasBOOLEAN { self: Environment =>
       case (INT(a), INT(b)) => Some(BOOLEAN(a <= b))
       case _ => None
     }
-    override def smt: String = "<="
+    override def smtName: String = "<="
   }
 }
 
@@ -51,7 +51,7 @@ trait HasINTgt extends HasINT with HasBOOLEAN { self: Environment =>
       case (INT(a), INT(b)) => Some(BOOLEAN(a > b))
       case _ => None
     }
-    override def smt: String = ">"
+    override def smtName: String = ">"
   }
 }
 
@@ -61,6 +61,6 @@ trait HasINTge extends HasINT with HasBOOLEAN { self: Environment =>
       case (INT(a), INT(b)) => Some(BOOLEAN(a >= b))
       case _ => None
     }
-    override def smt: String = ">="
+    override def smtName: String = ">="
   }
 }

--- a/src/main/scala/org/kframework/kale/builtin/INT.scala
+++ b/src/main/scala/org/kframework/kale/builtin/INT.scala
@@ -1,6 +1,7 @@
 package org.kframework.kale.builtin
 
 import org.kframework.kale.standard.ReferenceLabel
+import org.kframework.kale.util.Named
 import org.kframework.kale.{Environment, FunctionLabel2, Term}
 
 trait HasINT {
@@ -14,14 +15,48 @@ trait HasINT {
 trait HasINTdiv extends HasINT {
   self: Environment =>
 
-  val intDiv = new HasEnvironment with FunctionLabel2 {
+  val intDiv = new Named("_/Int_")(self) with FunctionLabel2 {
     def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
       case (_, INT(0)) => None
       case (INT(0), b) if b.isGround => Some(INT(0))
       case (INT(a), INT(b)) => Some(INT(a / b))
       case _ => None
     }
+  }
+}
 
-    override val name: String = "_/Int_"
+trait HasINTlt extends HasINT with HasBOOLEAN { self: Environment =>
+  val intLt = new Named("_<Int_")(self) with FunctionLabel2 {
+    def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
+      case (INT(a), INT(b)) => Some(BOOLEAN(a < b))
+      case _ => None
+    }
+  }
+}
+
+trait HasINTle extends HasINT with HasBOOLEAN { self: Environment =>
+  val intLe = new Named("_<=Int_")(self) with FunctionLabel2 {
+    def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
+      case (INT(a), INT(b)) => Some(BOOLEAN(a <= b))
+      case _ => None
+    }
+  }
+}
+
+trait HasINTgt extends HasINT with HasBOOLEAN { self: Environment =>
+  val intGt = new Named("_>Int_")(self) with FunctionLabel2 {
+    def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
+      case (INT(a), INT(b)) => Some(BOOLEAN(a > b))
+      case _ => None
+    }
+  }
+}
+
+trait HasINTge extends HasINT with HasBOOLEAN { self: Environment =>
+  val intGe = new Named("_>=Int_")(self) with FunctionLabel2 {
+    def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
+      case (INT(a), INT(b)) => Some(BOOLEAN(a >= b))
+      case _ => None
+    }
   }
 }

--- a/src/main/scala/org/kframework/kale/builtin/INT.scala
+++ b/src/main/scala/org/kframework/kale/builtin/INT.scala
@@ -20,6 +20,7 @@ trait HasINTplus extends HasINT { self: Environment =>
       case (INT(a), INT(b)) => Some(INT(a + b))
       case _ => None
     }
+    override def smtName: String = "+"
   }
 }
 
@@ -29,6 +30,7 @@ trait HasINTminus extends HasINT { self: Environment =>
       case (INT(a), INT(b)) => Some(INT(a + b))
       case _ => None
     }
+    override def smtName: String = "-"
   }
 }
 
@@ -38,6 +40,7 @@ trait HasINTmult extends HasINT { self: Environment =>
       case (INT(a), INT(b)) => Some(INT(a * b))
       case _ => None
     }
+    override def smtName: String = "*"
   }
 }
 
@@ -49,6 +52,7 @@ trait HasINTdiv extends HasINT { self: Environment =>
       case (INT(a), INT(b)) => Some(INT(a / b))
       case _ => None
     }
+    override def smtName: String = "div" // integer division, while "/" is real division.
   }
 }
 
@@ -58,6 +62,7 @@ trait HasINTmod extends HasINT { self: Environment =>
       case (INT(a), INT(b)) => Some(INT(a % b))
       case _ => None
     }
+    override def smtName: String = "mod" // z3 also has "rem", remainder.
   }
 }
 

--- a/src/main/scala/org/kframework/kale/builtin/INT.scala
+++ b/src/main/scala/org/kframework/kale/builtin/INT.scala
@@ -12,14 +12,50 @@ trait HasINT {
   }
 }
 
-trait HasINTdiv extends HasINT {
-  self: Environment =>
+trait HasINTbop extends HasINTplus with HasINTminus with HasINTmult with HasINTdiv with HasINTmod { self: Environment => }
 
+trait HasINTplus extends HasINT { self: Environment =>
+  val intPlus = new Named("_+Int_")(self) with FunctionLabel2 {
+    def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
+      case (INT(a), INT(b)) => Some(INT(a + b))
+      case _ => None
+    }
+  }
+}
+
+trait HasINTminus extends HasINT { self: Environment =>
+  val intMinus = new Named("_-Int_")(self) with FunctionLabel2 {
+    def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
+      case (INT(a), INT(b)) => Some(INT(a + b))
+      case _ => None
+    }
+  }
+}
+
+trait HasINTmult extends HasINT { self: Environment =>
+  val intMult = new Named("_*Int_")(self) with FunctionLabel2 {
+    def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
+      case (INT(a), INT(b)) => Some(INT(a * b))
+      case _ => None
+    }
+  }
+}
+
+trait HasINTdiv extends HasINT { self: Environment =>
   val intDiv = new Named("_/Int_")(self) with FunctionLabel2 {
     def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
-      case (_, INT(0)) => None
-      case (INT(0), b) if b.isGround => Some(INT(0))
+    //case (_, INT(0)) => None
+    //case (INT(0), b) if b.isGround => Some(INT(0))
       case (INT(a), INT(b)) => Some(INT(a / b))
+      case _ => None
+    }
+  }
+}
+
+trait HasINTmod extends HasINT { self: Environment =>
+  val intMod = new Named("_%Int_")(self) with FunctionLabel2 {
+    def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
+      case (INT(a), INT(b)) => Some(INT(a % b))
       case _ => None
     }
   }

--- a/src/main/scala/org/kframework/kale/builtin/INT.scala
+++ b/src/main/scala/org/kframework/kale/builtin/INT.scala
@@ -2,7 +2,7 @@ package org.kframework.kale.builtin
 
 import org.kframework.kale.standard.ReferenceLabel
 import org.kframework.kale.util.Named
-import org.kframework.kale.{Environment, FunctionLabel2, Term}
+import org.kframework.kale.{Environment, FunctionLabel2, Term, Z3Builtin}
 
 trait HasINT {
   self: Environment =>
@@ -26,37 +26,41 @@ trait HasINTdiv extends HasINT {
 }
 
 trait HasINTlt extends HasINT with HasBOOLEAN { self: Environment =>
-  val intLt = new Named("_<Int_")(self) with FunctionLabel2 {
+  val intLt = new Named("_<Int_")(self) with FunctionLabel2 with Z3Builtin {
     def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
       case (INT(a), INT(b)) => Some(BOOLEAN(a < b))
       case _ => None
     }
+    override def smt: String = "<"
   }
 }
 
 trait HasINTle extends HasINT with HasBOOLEAN { self: Environment =>
-  val intLe = new Named("_<=Int_")(self) with FunctionLabel2 {
+  val intLe = new Named("_<=Int_")(self) with FunctionLabel2 with Z3Builtin {
     def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
       case (INT(a), INT(b)) => Some(BOOLEAN(a <= b))
       case _ => None
     }
+    override def smt: String = "<="
   }
 }
 
 trait HasINTgt extends HasINT with HasBOOLEAN { self: Environment =>
-  val intGt = new Named("_>Int_")(self) with FunctionLabel2 {
+  val intGt = new Named("_>Int_")(self) with FunctionLabel2 with Z3Builtin {
     def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
       case (INT(a), INT(b)) => Some(BOOLEAN(a > b))
       case _ => None
     }
+    override def smt: String = ">"
   }
 }
 
 trait HasINTge extends HasINT with HasBOOLEAN { self: Environment =>
-  val intGe = new Named("_>=Int_")(self) with FunctionLabel2 {
+  val intGe = new Named("_>=Int_")(self) with FunctionLabel2 with Z3Builtin {
     def f(_1: Term, _2: Term): Option[Term] = (_1, _2) match {
       case (INT(a), INT(b)) => Some(BOOLEAN(a >= b))
       case _ => None
     }
+    override def smt: String = ">="
   }
 }

--- a/src/main/scala/org/kframework/kale/freeLabels.scala
+++ b/src/main/scala/org/kframework/kale/freeLabels.scala
@@ -1,7 +1,7 @@
 package org.kframework.kale
 
 
-trait Constructor
+trait Constructor extends NodeLabel
 
 trait FreeLabel extends Constructor
 
@@ -46,16 +46,18 @@ trait FreeLabel6 extends Label6 with FreeLabel {
   }
 }
 
-case class FreeNode0(label: Label0) extends Node0 with Application
+trait FreeNode // extends Node
 
-case class FreeNode1(label: Label1, _1: Term) extends Node1 with Application
+case class FreeNode0(label: Label0) extends Node0 with FreeNode with Application
 
-case class FreeNode2(label: Label2, _1: Term, _2: Term) extends Node2 with Application
+case class FreeNode1(label: Label1, _1: Term) extends Node1 with FreeNode with Application
 
-case class FreeNode3(label: Label3, _1: Term, _2: Term, _3: Term) extends Node3 with Application
+case class FreeNode2(label: Label2, _1: Term, _2: Term) extends Node2 with FreeNode with Application
 
-case class FreeNode4(label: Label4, _1: Term, _2: Term, _3: Term, _4: Term) extends Node4 with Application
+case class FreeNode3(label: Label3, _1: Term, _2: Term, _3: Term) extends Node3 with FreeNode with Application
 
-case class FreeNode5(label: Label5, _1: Term, _2: Term, _3: Term, _4: Term, _5: Term) extends Node5 with Application
+case class FreeNode4(label: Label4, _1: Term, _2: Term, _3: Term, _4: Term) extends Node4 with FreeNode with Application
 
-case class FreeNode6(label: Label6, _1: Term, _2: Term, _3: Term, _4: Term, _5: Term, _6: Term) extends Node6 with Application
+case class FreeNode5(label: Label5, _1: Term, _2: Term, _3: Term, _4: Term, _5: Term) extends Node5 with FreeNode with Application
+
+case class FreeNode6(label: Label6, _1: Term, _2: Term, _3: Term, _4: Term, _5: Term, _6: Term) extends Node6 with FreeNode with Application

--- a/src/main/scala/org/kframework/kale/km/KMEnvironment.scala
+++ b/src/main/scala/org/kframework/kale/km/KMEnvironment.scala
@@ -7,7 +7,14 @@ import org.kframework.kale._
 
 import scala.collection._
 
-class KMEnvironment extends DNFEnvironment with HasINT with HasINTdiv with HasINTcmp with HasID {
+trait HasBuiltin
+  extends HasINT with HasINTbop with HasINTcmp
+  with HasID
+  with HasBOOLEAN
+  with HasSTRING
+{ self: Environment => }
+
+class KMEnvironment extends DNFEnvironment with HasBuiltin {
   private implicit val env = this
 
   private val sorts = mutable.Map[Label, Signature]()

--- a/src/main/scala/org/kframework/kale/km/KMEnvironment.scala
+++ b/src/main/scala/org/kframework/kale/km/KMEnvironment.scala
@@ -7,7 +7,7 @@ import org.kframework.kale._
 
 import scala.collection._
 
-class KMEnvironment extends DNFEnvironment with HasINT with HasINTdiv with HasINTlt with HasINTle with HasINTgt with HasINTge with HasID {
+class KMEnvironment extends DNFEnvironment with HasINT with HasINTdiv with HasINTcmp with HasID {
   private implicit val env = this
 
   private val sorts = mutable.Map[Label, Signature]()

--- a/src/main/scala/org/kframework/kale/km/KMEnvironment.scala
+++ b/src/main/scala/org/kframework/kale/km/KMEnvironment.scala
@@ -1,13 +1,13 @@
 package org.kframework.kale.km
 
 import org.kframework.kale
-import org.kframework.kale.builtin.{HasID, HasINT, HasINTdiv}
+import org.kframework.kale.builtin._
 import org.kframework.kale.standard._
 import org.kframework.kale.{Sort => _, _}
 
 import scala.collection._
 
-class KMEnvironment extends DNFEnvironment with HasINT with HasINTdiv with HasID {
+class KMEnvironment extends DNFEnvironment with HasINT with HasINTdiv with HasINTlt with HasINTle with HasINTgt with HasINTge with HasID {
   private implicit val env = this
 
   private val sorts = mutable.Map[Label, Signature]()

--- a/src/main/scala/org/kframework/kale/km/KMEnvironment.scala
+++ b/src/main/scala/org/kframework/kale/km/KMEnvironment.scala
@@ -3,7 +3,7 @@ package org.kframework.kale.km
 import org.kframework.kale
 import org.kframework.kale.builtin._
 import org.kframework.kale.standard._
-import org.kframework.kale.{Sort => _, _}
+import org.kframework.kale._
 
 import scala.collection._
 
@@ -12,7 +12,15 @@ class KMEnvironment extends DNFEnvironment with HasINT with HasINTdiv with HasIN
 
   private val sorts = mutable.Map[Label, Signature]()
 
-  case class Signature(args: Seq[Sort], target: Sort)
+  case class Signature(args: Seq[kale.Sort], target: kale.Sort)
+
+  def sortArgs(l: Label): Seq[kale.Sort] = sorts.get(l).map({ signature => signature.args}).getOrElse({
+    throw new AssertionError("Could not find Signature for label: " + l)
+  })
+
+  def sortTarget(l: Label): kale.Sort = sorts.get(l).map({ signature => signature.target}).getOrElse({
+    throw new AssertionError("Could not find Signature for label: " + l)
+  })
 
   override def sort(l: Label, children: Seq[Term]): kale.Sort = sorts.get(l).map({ signature =>
     assert(children.map(_.sort) == signature.args)
@@ -21,24 +29,20 @@ class KMEnvironment extends DNFEnvironment with HasINT with HasINTdiv with HasIN
     throw new AssertionError("Could not find Signature for label: " + l)
   })
 
-  def targetSort(l: Label): kale.Sort = sorts.get(l).map({signature => signature.target}).getOrElse({
-    throw new AssertionError("Could not find Signature for label: " + l)
-  })
-
   def sorted(l: Label, signature: Signature): Unit = {
     sorts.put(l, signature)
   }
 
   // TODO: move the util functions below somewhere else
-  def sorted(l: LeafLabel[_], target: Sort): Unit = sorted(l, Signature(Seq(), target))
+  def sorted(l: LeafLabel[_], target: kale.Sort): Unit = sorted(l, Signature(Seq(), target))
 
-  def sorted(l: Label0, target: Sort): Unit = sorted(l, Signature(Seq(), target))
+  def sorted(l: Label0, target: kale.Sort): Unit = sorted(l, Signature(Seq(), target))
 
-  def sorted(l: Label1, arg1: Sort, target: Sort): Unit = sorted(l, Signature(Seq(arg1), target))
+  def sorted(l: Label1, arg1: kale.Sort, target: kale.Sort): Unit = sorted(l, Signature(Seq(arg1), target))
 
-  def sorted(l: Label2, arg1: Sort, arg2: Sort, target: Sort): Unit = sorted(l, Signature(Seq(arg1, arg2), target))
+  def sorted(l: Label2, arg1: kale.Sort, arg2: kale.Sort, target: kale.Sort): Unit = sorted(l, Signature(Seq(arg1, arg2), target))
 
-  def sorted(l: Label3, arg1: Sort, arg2: Sort, arg3: Sort, target: Sort): Unit = sorted(l, Signature(Seq(arg1, arg2, arg3), target))
+  def sorted(l: Label3, arg1: kale.Sort, arg2: kale.Sort, arg3: kale.Sort, target: kale.Sort): Unit = sorted(l, Signature(Seq(arg1, arg2, arg3), target))
 
   override val substitutionMaker: (Substitution) => SubstitutionApply = new SubstitutionApply(_)
 }

--- a/src/main/scala/org/kframework/kale/km/MultiSortedUnifier.scala
+++ b/src/main/scala/org/kframework/kale/km/MultiSortedUnifier.scala
@@ -31,7 +31,7 @@ class MultiSortedUnifier(val env: KMEnvironment) extends kale.MatcherOrUnifier {
     case (_, And) => TermAnd _
     case (Or, _) => OrTerm _
     case (_, Or) => TermOr _
-    case (l1: FreeLabel, l2: FreeLabel) if l1 != l2 || env.targetSort(l1) != env.targetSort(l2) => NoMatch _
+    case (l1: FreeLabel, l2: FreeLabel) if l1 != l2 || env.sortTarget(l1) != env.sortTarget(l2) => NoMatch _
   })
     .orElse(freeLabelProcessing)
     .orElse(functionDefinedByRewritingProcessing)

--- a/src/main/scala/org/kframework/kale/logic.scala
+++ b/src/main/scala/org/kframework/kale/logic.scala
@@ -78,20 +78,20 @@ trait Top extends Truth with Substitution with kore.Top
 trait Bottom extends Truth with kore.Bottom
 
 
-trait AndLabel extends AssocCommWithIdLabel {
+trait AndLabel extends AssocCommWithIdLabel with Z3Builtin {
   override val identity = env.Top
   assert(identity != null)
   def asSubstitutionAndTerms(t: Term): (Substitution, Set[Term])
 }
 
-trait OrLabel extends AssocCommWithIdLabel {
+trait OrLabel extends AssocCommWithIdLabel with Z3Builtin {
   override val identity = env.Bottom
   assert(identity != null)
 }
 
 trait RewriteLabel extends Label2
 
-trait EqualityLabel extends Label2 {
+trait EqualityLabel extends Label2 with Z3Builtin {
   def binding(_1: Variable, _2: Term): Binding
 }
 

--- a/src/main/scala/org/kframework/kale/logic.scala
+++ b/src/main/scala/org/kframework/kale/logic.scala
@@ -27,6 +27,8 @@ trait DomainValue[T] extends Leaf[T] with kore.DomainValue {
 trait Sort extends kore.Sort {
   val name: String
 
+  def smtName: String = name
+
   override def equals(other: Any): Boolean = other match {
     case that: Sort => that.name == name
     case _ => false

--- a/src/main/scala/org/kframework/kale/logic.scala
+++ b/src/main/scala/org/kframework/kale/logic.scala
@@ -95,7 +95,7 @@ trait EqualityLabel extends Label2 with Z3Builtin {
   def binding(_1: Variable, _2: Term): Binding
 }
 
-trait NotLabel extends Label1
+trait NotLabel extends Label1 with Z3Builtin
 
 trait Equals extends kore.Equals with Node2 with BinaryInfix {
   override lazy val isPredicate: Boolean = true

--- a/src/main/scala/org/kframework/kale/standard/StandardEnvironment.scala
+++ b/src/main/scala/org/kframework/kale/standard/StandardEnvironment.scala
@@ -21,5 +21,12 @@ trait StandardEnvironment extends DNFEnvironment with HasBOOLEAN with HasINT wit
 
   override def sort(l: Label, children: Seq[Term]): kale.Sort = Sort.K
 
+  override def sortTarget(l: Label): kale.Sort = Sort.K
+
+  override def sortArgs(l: Label): Seq[kale.Sort] = l match {
+    case l:LeafLabel[_] => Seq()
+    case l:NodeLabel => Seq.fill(l.arity)(Sort.K)
+  }
+
   override val substitutionMaker: (Substitution) => SubstitutionApply = new SubstitutionWithContext(_)
 }

--- a/src/main/scala/org/kframework/kale/term.scala
+++ b/src/main/scala/org/kframework/kale/term.scala
@@ -11,6 +11,8 @@ trait Label extends MemoizedHashCode with kore.Symbol {
 
   val name: String
 
+  def smt: String = name
+
   val id: Int = env.register(this)
 
   override def equals(other: Any): Boolean = other match {

--- a/src/main/scala/org/kframework/kale/term.scala
+++ b/src/main/scala/org/kframework/kale/term.scala
@@ -11,7 +11,7 @@ trait Label extends MemoizedHashCode with kore.Symbol {
 
   val name: String
 
-  def smt: String = name
+  def smtName: String = name
 
   val id: Int = env.register(this)
 

--- a/src/main/scala/org/kframework/kale/z3.scala
+++ b/src/main/scala/org/kframework/kale/z3.scala
@@ -1,0 +1,130 @@
+package org.kframework.kale
+
+import scala.collection._
+import scala.sys.process._
+
+trait Z3Builtin
+
+class z3(val env: Environment) {
+
+  import env._
+
+  @throws(classOf[z3.Fail])
+  def sat(term: Term): Boolean = term match {
+    case Top => true
+    case Bottom => false
+    case _ => satZ3(term)
+  }
+
+  @throws(classOf[z3.Fail])
+  def satZ3(term: Term): Boolean = {
+    val query = declare(term) + "\n(assert " + encode(term) + ")\n" + "(check-sat)\n"
+    val (exitValue, stdout, stderr) = z3.run(query)
+    if (exitValue == 0) stdout == "sat"
+    else throw z3.Fail(stdout + stderr)
+  }
+
+  @throws(classOf[z3.Fail])
+  def implies(t1: Term, t2: Term): Boolean = {
+    // t1 -> t2 valid  iff  t1 /\ !t2 unsat
+    !sat(And(t1, Not(t2)))
+  }
+
+  def encode(term: Term): String = term match {
+    case t:Equals => "(= " + encode(t._1) + " " + encode(t._2) + ")"
+    case t:And => "(and " + encode(t._1) + " " + encode(t._2) + ")"
+    case t:Or => "(or " + encode(t._1) + " " + encode(t._2) + ")"
+    case FreeNode0(symbol) => symbol.smt
+    case t:FreeNode => "(" + t.label.smt + " " + t.children.map(encode).mkString(" ") + ")"
+    case v:Variable => v.name.toString
+    case c:DomainValue[_] => c.toString
+    case _ => ???
+  }
+
+  def declare(term: Term): String = {
+    // gather functional symbols and variables, where variables are supposed to be encoded as constants
+    def getFunctionSymbols(term: Term): Set[Any] = term match {
+      case t:Node =>
+        val decls = t.children.flatMap(getFunctionSymbols).toSet
+        if (!t.label.isInstanceOf[Z3Builtin]) decls + t.label
+        else decls
+      case _:Variable => Set(term)
+      case _:DomainValue[_] => Set()
+      case _ => ???
+    }
+    val symbols = getFunctionSymbols(term)
+    // function (i.e., non-constructor) symbols
+    // - variables and zero-argument symbols as `const`
+    // - non-zero-argument symbols as `fun`
+    val declareFuns: String = symbols.map({
+      case v:Variable => "(declare-const " + v.name + " " + v.sort.name + ")\n"
+      case l:FreeLabel0 => "(declare-const " + l.smt + " " + sortTarget(l).name + ")\n"
+      case l:FreeLabel => "(declare-fun " + l.smt + " (" + sortArgs(l).map(_.name).mkString(" ") + ") " + sortTarget(l).name + ")\n"
+      case _ => ???
+    }).mkString
+    // remaining sorts not defined by constructor datatypes
+    val sorts: Set[Sort] = symbols.flatMap({
+      case l:FreeLabel => sortArgs(l).toSet + sortTarget(l)
+      case v:Variable => Set(v.sort)
+      case _ => ???
+    })
+    val declareSorts = (sorts -- datatypes)
+      .map(sort => if (sort.isInstanceOf[Z3Builtin]) "" else "(declare-sort " + sort.name + ")\n").mkString
+    declareSorts + declDatatypes + declareFuns
+  }
+  lazy val datatypes: Set[Sort] = Set()
+  lazy val declDatatypes: String = ""
+
+  // TODO:
+//  lazy val datatypes: Set[Sort] = symbolsSeq.flatMap(_.flatMap(s => s.signature._1.toSet + s.signature._2).toSet).toSet
+//  lazy val declDatatypes: String = declareDatatypesSeq(symbolsSeq)
+//
+//  // symbolsSeq: SCCs of symbols in topological order
+//  def declareDatatypesSeq(symbolsSeq: Seq[Seq[Symbol]]): String = symbolsSeq.map(declareDatatypes).mkString
+//  def declareDatatypes(symbols: Seq[Symbol]): String = {
+//    "(declare-datatypes () (\n" +
+//      symbols.filter(sym => !sym.isFunctional && !sym.smtBuiltin)
+//        .groupBy(_.signature._2)
+//        .map({case (sort, syms) =>
+//          "  (" + sort.smt + "\n" +
+//            syms.map(sym =>
+//              "    (" + sym.smt + " " + sym.signature._1.zipWithIndex.map({case (s,i) => "(" + sym.smt + i + " " + s.smt + ")"}).mkString(" ") + ")\n"
+//            ).mkString +
+//            "  )\n"
+//        }).mkString +
+//      "))\n"
+//  }
+
+}
+
+object z3 {
+
+  // TODO: set proper z3 path
+  private val z3 = "../z3/bin/z3" // "z3-4.5.0-x64-osx-10.11.6/bin/z3"
+
+  val cmd = Seq(z3, "-smt2", "-in")
+
+  def run(query: String): (Int, String, String) = {
+    val stdinJob: (java.io.OutputStream) => Unit = out => {
+      out.write(query.getBytes())
+      out.close()
+    }
+    var stdout: String = ""
+    val stdoutJob: (java.io.InputStream) => Unit = in => {
+      stdout = scala.io.Source.fromInputStream(in).getLines.mkString("\n")
+      in.close()
+    }
+    var stderr: String = ""
+    val stderrJob: (java.io.InputStream) => Unit = in => {
+      stderr = scala.io.Source.fromInputStream(in).getLines.mkString("\n")
+      in.close()
+    }
+    val pio = new ProcessIO(stdinJob, stdoutJob, stderrJob)
+    val exitValue = Process(cmd).run(pio).exitValue()
+    (exitValue, stdout, stderr)
+  }
+
+  case class Fail(msg: String) extends Exception
+
+}
+

--- a/src/main/scala/org/kframework/kale/z3.scala
+++ b/src/main/scala/org/kframework/kale/z3.scala
@@ -34,8 +34,8 @@ class z3(val env: Environment, val symbolsSeq: Seq[Seq[Label]]) {
     case t:Equals => "(= " + encode(t._1) + " " + encode(t._2) + ")"
     case t:And => "(and " + encode(t._1) + " " + encode(t._2) + ")"
     case t:Or => "(or " + encode(t._1) + " " + encode(t._2) + ")"
-    case FreeNode0(symbol) => symbol.smt
-    case t:FreeNode => "(" + t.label.smt + " " + t.children.map(encode).mkString(" ") + ")"
+    case FreeNode0(symbol) => symbol.smtName
+    case t:FreeNode => "(" + t.label.smtName + " " + t.children.map(encode).mkString(" ") + ")"
     case v:Variable => v.name.toString
     case c:DomainValue[_] => c.toString
     case _ => ???
@@ -58,8 +58,8 @@ class z3(val env: Environment, val symbolsSeq: Seq[Seq[Label]]) {
     // - non-zero-argument symbols as `fun`
     val declareFuns: String = symbols.map({
       case v:Variable => "(declare-const " + v.name + " " + v.sort.name + ")\n"
-      case l:FreeLabel0 => "(declare-const " + l.smt + " " + sortTarget(l).name + ")\n"
-      case l:FreeLabel => "(declare-fun " + l.smt + " (" + sortArgs(l).map(_.name).mkString(" ") + ") " + sortTarget(l).name + ")\n"
+      case l:FreeLabel0 => "(declare-const " + l.smtName + " " + sortTarget(l).name + ")\n"
+      case l:FreeLabel => "(declare-fun " + l.smtName + " (" + sortArgs(l).map(_.name).mkString(" ") + ") " + sortTarget(l).name + ")\n"
       case _ => ???
     }).mkString
     // remaining sorts not defined by constructor datatypes
@@ -84,7 +84,7 @@ class z3(val env: Environment, val symbolsSeq: Seq[Seq[Label]]) {
         .map({case (sort, syms) =>
           "  (" + sort.name + "\n" +
             syms.map(sym =>
-              "    (" + sym.smt + " " + sortArgs(sym).zipWithIndex.map({case (s,i) => "(" + sym.smt + i + " " + s.name + ")"}).mkString(" ") + ")\n"
+              "    (" + sym.smtName + " " + sortArgs(sym).zipWithIndex.map({case (s,i) => "(" + sym.smtName + i + " " + s.name + ")"}).mkString(" ") + ")\n"
             ).mkString +
             "  )\n"
         }).mkString +

--- a/src/main/scala/org/kframework/kale/z3.scala
+++ b/src/main/scala/org/kframework/kale/z3.scala
@@ -5,6 +5,10 @@ import scala.sys.process._
 
 trait Z3Builtin
 
+/*
+  symbolsSeq: constructor symbols that need to be encoded using z3 datatypes instead of functions.
+  It should be given as SCCs of symbols in topological order of dependency.
+ */
 class z3(val env: Environment, val symbolsSeq: Seq[Seq[Label]]) {
 
   import env._
@@ -72,7 +76,8 @@ class z3(val env: Environment, val symbolsSeq: Seq[Seq[Label]]) {
       .map(sort => if (sort.isInstanceOf[Z3Builtin]) "" else "(declare-sort " + sort.smtName + ")\n").mkString
     declareSorts + declDatatypes + declareFuns
   }
-  lazy val datatypes: Set[Sort] = symbolsSeq.flatMap(_.flatMap(s => sortArgs(s).toSet + sortTarget(s)).toSet).toSet
+//lazy val datatypes: Set[Sort] = symbolsSeq.flatMap(_.flatMap(s => sortArgs(s).toSet + sortTarget(s)).toSet).toSet
+  lazy val datatypes: Set[Sort] = symbolsSeq.flatMap(_.map(sortTarget).toSet).toSet
   lazy val declDatatypes: String = declareDatatypesSeq(symbolsSeq)
 
   // symbolsSeq: SCCs of symbols in topological order

--- a/src/main/scala/org/kframework/kale/z3.scala
+++ b/src/main/scala/org/kframework/kale/z3.scala
@@ -57,9 +57,9 @@ class z3(val env: Environment, val symbolsSeq: Seq[Seq[Label]]) {
     // - variables and zero-argument symbols as `const`
     // - non-zero-argument symbols as `fun`
     val declareFuns: String = symbols.map({
-      case v:Variable => "(declare-const " + v.name + " " + v.sort.name + ")\n"
-      case l:FreeLabel0 => "(declare-const " + l.smtName + " " + sortTarget(l).name + ")\n"
-      case l:FreeLabel => "(declare-fun " + l.smtName + " (" + sortArgs(l).map(_.name).mkString(" ") + ") " + sortTarget(l).name + ")\n"
+      case v:Variable => "(declare-const " + v.name + " " + v.sort.smtName + ")\n"
+      case l:FreeLabel0 => "(declare-const " + l.smtName + " " + sortTarget(l).smtName + ")\n"
+      case l:FreeLabel => "(declare-fun " + l.smtName + " (" + sortArgs(l).map(_.smtName).mkString(" ") + ") " + sortTarget(l).smtName + ")\n"
       case _ => ???
     }).mkString
     // remaining sorts not defined by constructor datatypes
@@ -69,7 +69,7 @@ class z3(val env: Environment, val symbolsSeq: Seq[Seq[Label]]) {
       case _ => ???
     })
     val declareSorts = (sorts -- datatypes)
-      .map(sort => if (sort.isInstanceOf[Z3Builtin]) "" else "(declare-sort " + sort.name + ")\n").mkString
+      .map(sort => if (sort.isInstanceOf[Z3Builtin]) "" else "(declare-sort " + sort.smtName + ")\n").mkString
     declareSorts + declDatatypes + declareFuns
   }
   lazy val datatypes: Set[Sort] = symbolsSeq.flatMap(_.flatMap(s => sortArgs(s).toSet + sortTarget(s)).toSet).toSet
@@ -82,9 +82,9 @@ class z3(val env: Environment, val symbolsSeq: Seq[Seq[Label]]) {
       symbols.filter(sym => !sym.isInstanceOf[Z3Builtin])
         .groupBy(sortTarget)
         .map({case (sort, syms) =>
-          "  (" + sort.name + "\n" +
+          "  (" + sort.smtName + "\n" +
             syms.map(sym =>
-              "    (" + sym.smtName + " " + sortArgs(sym).zipWithIndex.map({case (s,i) => "(" + sym.smtName + i + " " + s.name + ")"}).mkString(" ") + ")\n"
+              "    (" + sym.smtName + " " + sortArgs(sym).zipWithIndex.map({case (s,i) => "(" + sym.smtName + i + " " + s.smtName + ")"}).mkString(" ") + ")\n"
             ).mkString +
             "  )\n"
         }).mkString +

--- a/src/test/scala/org/kframework/kale/km/RewriteTest.scala
+++ b/src/test/scala/org/kframework/kale/km/RewriteTest.scala
@@ -1,6 +1,6 @@
 package org.kframework.kale.km
 
-import org.kframework.kale.{And, Rewriter, SubstitutionApply}
+import org.kframework.kale.{And, Rewriter, SubstitutionApply, Z3Builtin}
 import org.kframework.kale.standard._
 import org.scalatest.FreeSpec
 
@@ -12,7 +12,7 @@ class RewriteTest extends FreeSpec {
   // sort delcarations
   object Sorts {
     val Id = Sort("Id")
-    val Int = Sort("Int")
+    val Int = new Sort("Int") with Z3Builtin
     val K = Sort("K")
   }
   import Sorts._
@@ -98,8 +98,10 @@ class RewriteTest extends FreeSpec {
     // rule q(x:Int) => d if x < 0
     // p(x) =*=> [ c /\ x>= 0 /\ x > 0 ]
     val rr = rewriter(Set(r1,r2,r3))
-    println(
+    assert(
       rr.searchStep(rr.searchStep(t1))
+        ==
+      And(Seq(c(), Equality(intGe(X,INT(0)), BOOLEAN(true)), Equality(intGt(X,INT(0)), BOOLEAN(true))))
     )
 
   }

--- a/src/test/scala/org/kframework/kale/km/RewriteTest.scala
+++ b/src/test/scala/org/kframework/kale/km/RewriteTest.scala
@@ -49,11 +49,17 @@ class RewriteTest extends FreeSpec {
 
     // rule a => b
     // a => [ b ]
-    println(rewriter(Set(r1)).searchStep(t1))
+    assert(rewriter(Set(r1)).searchStep(t1) == b())
 
     // rule b => c
     // a =*=> [ ]
-    println(rewriter(Set(r2)).searchStep(t1))
+    assert(rewriter(Set(r2)).searchStep(t1) == Bottom)
+
+    // rule a => b
+    // rule b => c
+    // a => [ c ]
+    val rr = rewriter(Set(r1,r2))
+    assert(rr.searchStep(rr.searchStep(t1)) == c())
 
   }
 


### PR DESCRIPTION
@cos I made a first cut of z3 encoding. Now we can run the following symbolically. (Note that the third rule should *not* be applied if we start with `p(x)`, and the current z3 encoding is enough to reason about it.)

```
+    // rule p(x:Int) => q(x) if x > 0
+    // rule q(x:Int) => c if x >= 0
+    // rule q(x:Int) => d if x < 0
```

Note that I made a couple of changes to the kale data structure, and you may want to take a look at it. Especially, I put additional information for Label and Sort that tells whether it is z3-builtin function or sort, by creating trait `Z3Builtin` and having them inherit the trait, (as you suggested last time.) Of course, we can put it as a member field as well. We can talk about it if you want.

Also, note that this PR is based on kale/master and kore/master branches. I couldn't start to work on the top of the latest branches, i.e., kale/imp+kale and kore/add-interfaces, because I couldn't make the sbt build work.

It would be good if you can try to merge this with your latest works to see if there is no conflict, before I go too further.