### PR TITLE
Include kore as a submodule instead of via sbt's resolvers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kore"]
+	path = kore
+	url = https://github.com/kframework/kore

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,8 +1,29 @@
-# Build it yourself
+## Building
+
+Clone the repository (recursively to include submodules) and then build using
+`sbt`. Use the `develop` branch if you intend to create pull requests: 
 
 ```
+git clone --recurse-submodules https://github.com/kframework/kale --branch develop
 sbt compile
 ```
+
+These git configuration settings smoothen out working with submodules:
+
+```
+git config --global push.recurseSubmodules check
+git config --global fetch.recurseSubmodules true
+```
+
+If you intend to push to the `kore` repository too, using you SSH adding:
+
+```
+[url "git@github.com.:"]
+    pushInsteadOf = https://github.com/
+```
+
+to your `~/.gitconfig` will let you do that.
+
 
 ## Guide on adding a new feature to terms/labels
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,13 +10,14 @@ resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repos
 
 resolvers += Resolver.mavenLocal
 
+lazy val root = project.in(file(".")).dependsOn(kore)
+lazy val kore = RootProject(file("kore"))
+
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
 
   "io.circe" %% "circe-core" % "0.8.0",
-  "io.circe" %% "circe-parser" % "0.8.0",
-
-  "org.kframework.k" %% "kore" % "0.6-SNAPSHOT"
+  "io.circe" %% "circe-parser" % "0.8.0"
 )
 
 lazy val installZ3 = taskKey[Unit]("Install Z3 theorem prover")


### PR DESCRIPTION
Using Maven "-SNAPSHOT" mechanism is prettry fragile, because
the dependencies between the projects aren't explict. Maven and sbt
aren't able to tell if we're using the right version kore, leading
to breaking builds.

Closes #19 